### PR TITLE
Make the streaming implementation more robust

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,21 +21,15 @@ message(STATUS "LIBSDRPLAY_LIBRARIES - ${LIBSDRPLAY_LIBRARIES}")
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${LIBSDRPLAY_INCLUDE_DIRS})
 
+# As SoapySDR requires this, we can safely
+# do the same
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 #enable c++11 features
 if(CMAKE_COMPILER_IS_GNUCXX)
-
-    #C++11 is a required language feature for this project
-    include(CheckCXXCompilerFlag)
-    CHECK_CXX_COMPILER_FLAG("-std=c++11" HAS_STD_CXX11)
-    if(HAS_STD_CXX11)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-    else(HAS_STD_CXX11)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
-    endif()
-
     #disable warnings for unused parameters
     add_definitions(-Wno-unused-parameter)
-
 endif(CMAKE_COMPILER_IS_GNUCXX)
 
 # Configurable feature set 

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -756,7 +756,7 @@ SoapySDR::ArgInfoList SoapySDRPlay::getFrequencyArgsInfo(const int direction, co
  ******************************************************************/
 
 /* input_sample_rate:  sample rate used by the SDR
- * output_sample_rate: sample rate the as seen by the client app
+ * output_sample_rate: sample rate as seen by the client app
  *                     (<= input_sample_rate because of decimation)
  */
 

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -1643,7 +1643,6 @@ void SoapySDRPlay::releaseDevice()
             sdrplay_api_UnlockDeviceApi();
             SoapySDR_logf(SOAPY_SDR_ERROR, "ReleaseDevice Error: %s", sdrplay_api_GetErrorString(err));
             throw std::runtime_error("ReleaseDevice() failed");
-            return;
         }
         deviceSelected = nullptr;
     }
@@ -1660,7 +1659,6 @@ void SoapySDRPlay::selectDevice()
         sdrplay_api_UnlockDeviceApi();
         SoapySDR_logf(SOAPY_SDR_ERROR, "SelectDevice Error: %s", sdrplay_api_GetErrorString(err));
         throw std::runtime_error("SelectDevice() failed");
-        return;
     }
 
     sdrplay_api_UnlockDeviceApi();

--- a/SoapySDRPlay.hpp
+++ b/SoapySDRPlay.hpp
@@ -46,7 +46,7 @@
 class SoapySDRPlay: public SoapySDR::Device
 {
 public:
-    SoapySDRPlay(const SoapySDR::Kwargs &args);
+    explicit SoapySDRPlay(const SoapySDR::Kwargs &args);
 
     ~SoapySDRPlay(void);
 

--- a/SoapySDRPlay.hpp
+++ b/SoapySDRPlay.hpp
@@ -296,6 +296,7 @@ public:
         std::vector<std::vector<short> > buffs;
         size_t      head;
         size_t      tail;
+        /// number of in-flight buffers
         size_t      count;
         short *currentBuff;
         bool overflowEvent;

--- a/Streaming.cpp
+++ b/Streaming.cpp
@@ -105,6 +105,9 @@ void SoapySDRPlay::rx_callback(short *xi, short *xq, unsigned int numSamples,
 
     // get current fill buffer
     auto &buff = stream->buffs[stream->tail];
+
+    // we do not reallocate here, as we only resize within
+    // the buffers capacity
     buff.resize(buff.size() + spaceReqd);
 
     // copy into the buffer queue
@@ -194,7 +197,6 @@ SoapySDRPlay::SoapySDRPlayStream::SoapySDRPlayStream(size_t channel,
     // allocate buffers
     buffs.resize(numBuffers);
     for (auto &buff : buffs) buff.reserve(bufferLength);
-    for (auto &buff : buffs) buff.clear();
 }
 
 SoapySDRPlay::SoapySDRPlayStream::~SoapySDRPlayStream()
@@ -370,7 +372,8 @@ int SoapySDRPlay::readStream(SoapySDR::Stream *stream,
 {
     if (!streamActive)
     {
-        return 0;
+        // TODO: wait timeoutUS and try again
+        return SOAPY_SDR_TIMEOUT;
     }
 
     SoapySDRPlayStream *sdrplay_stream = reinterpret_cast<SoapySDRPlayStream *>(stream);

--- a/Streaming.cpp
+++ b/Streaming.cpp
@@ -404,7 +404,7 @@ int SoapySDRPlay::readStream(SoapySDR::Stream *stream,
     }
     else
     {
-        std::memcpy(buffs[0], (float*)((void*)sdrplay_stream->currentBuff), returnedElems * 2 * sizeof(float));
+        std::memcpy(buffs[0], (float *)(void*)sdrplay_stream->currentBuff, returnedElems * 2 * sizeof(float));
     }
 
     // bump variables for next call into readStream

--- a/Streaming.cpp
+++ b/Streaming.cpp
@@ -279,7 +279,7 @@ int SoapySDRPlay::activateStream(SoapySDR::Stream *stream,
 {
     if (flags != 0)
     {
-        throw std::runtime_error("error in activateStream() - flags != 0");
+        SoapySDR_log(SOAPY_SDR_ERROR, "error in activateStream() - flags != 0");
         return SOAPY_SDR_NOT_SUPPORTED;
     }
 
@@ -316,7 +316,6 @@ int SoapySDRPlay::activateStream(SoapySDR::Stream *stream,
     if (err != sdrplay_api_Success)
     {
         SoapySDR_logf(SOAPY_SDR_ERROR, "error in activateStream() - Init() failed: %s", sdrplay_api_GetErrorString(err));
-        throw std::runtime_error("error in activateStream() - Init() failed");
         return SOAPY_SDR_NOT_SUPPORTED;
     }
 
@@ -377,8 +376,8 @@ int SoapySDRPlay::readStream(SoapySDR::Stream *stream,
     SoapySDRPlayStream *sdrplay_stream = reinterpret_cast<SoapySDRPlayStream *>(stream);
     if (_streams[sdrplay_stream->channel] == 0)
     {
-        throw std::runtime_error("readStream stream not activated");
-        return 0;
+        //throw std::runtime_error("readStream stream not activated");
+        return SOAPY_SDR_STREAM_ERROR;
     }
 
     // are elements left in the buffer? if not, do a new read.
@@ -388,8 +387,8 @@ int SoapySDRPlay::readStream(SoapySDR::Stream *stream,
 
         if (ret < 0)
         {
-            SoapySDR_logf(SOAPY_SDR_ERROR, "readStream() failed: %s", SoapySDR_errToStr(ret));
-            throw std::runtime_error("readStream() failed");
+            // Do not generate logs here, as interleaving with stream indicators
+            //SoapySDR_logf(SOAPY_SDR_WARNING, "readStream() failed: %s", SoapySDR_errToStr(ret));
             return ret;
         }
         sdrplay_stream->nElems = ret;
@@ -405,7 +404,7 @@ int SoapySDRPlay::readStream(SoapySDR::Stream *stream,
     }
     else
     {
-        std::memcpy(buffs[0], (float *)sdrplay_stream->currentBuff, returnedElems * 2 * sizeof(float));
+        std::memcpy(buffs[0], (float*)((void*)sdrplay_stream->currentBuff), returnedElems * 2 * sizeof(float));
     }
 
     // bump variables for next call into readStream

--- a/Streaming.cpp
+++ b/Streaming.cpp
@@ -25,6 +25,8 @@
  */
 
 #include "SoapySDRPlay.hpp"
+#include <thread>
+#include <chrono>
 
 // globals declared in Registration.cpp
 extern SoapySDR::Stream *activeStream;
@@ -370,10 +372,15 @@ int SoapySDRPlay::readStream(SoapySDR::Stream *stream,
                              long long &timeNs,
                              const long timeoutUs)
 {
+    // the API requests us to wait until either the
+    // timeout is reached or the stream is activated
     if (!streamActive)
     {
-        // TODO: wait timeoutUS and try again
-        return SOAPY_SDR_TIMEOUT;
+        using us = std::chrono::microseconds;
+        std::this_thread::sleep_for(us(timeoutUs));
+        if(!streamActive){
+            return SOAPY_SDR_TIMEOUT;
+        }
     }
 
     SoapySDRPlayStream *sdrplay_stream = reinterpret_cast<SoapySDRPlayStream *>(stream);


### PR DESCRIPTION
This PR mainly addresses the following issues:

- no exceptions in streaming API (use return codes instead)
- no logs on certain (common) events (this otherwise breaks the stream indicators when using SoapySDRUtil rate testing
- Fulfill soapy's client behavior expectations
- Bump minimal CXX version to 11 (this is necessary for SoapySDR anyways)